### PR TITLE
Fixed regex to include Windows type line-ending.

### DIFF
--- a/src/ajaxInclude.js
+++ b/src/ajaxInclude.js
@@ -103,7 +103,7 @@
 						targetEl = target ? $( target ) : el;
 
 					if( o.proxy ){
-						var subset = content.match( new RegExp( "<entry url=[\"']?" + el.data( "url" ) + "[\"']?>(?:(?!</entry>)(.|\n))*", "gmi" ) );
+						var subset = content.match( new RegExp( "<entry url=[\"']?" + el.data( "url" ) + "[\"']?>(?:(?!</entry>)(.|\r\n))*", "gmi" ) );
 						if( subset ){
 							content = subset[ 0 ];
 						}

--- a/src/ajaxInclude.js
+++ b/src/ajaxInclude.js
@@ -144,4 +144,4 @@
 	};
 
 	win.AjaxInclude = AI;
-}( jQuery, this ));
+}( $, this ));


### PR DESCRIPTION
I've had this problem for a while and didn't quite know what it was until I
searched for the different line endings. I've tested this on Unix but on Linux only on my S3.

I'm I missing anything or is this not really a problem ?