### PR TITLE
Fix Regex Bug

### DIFF
--- a/src/ajaxInclude.js
+++ b/src/ajaxInclude.js
@@ -104,8 +104,8 @@
 
 					if( o.proxy ){
 						var subset = new RegExp("<entry url=[\"']?" + el.data("url") + "[\"']?>((?:(?!</entry>)(.|\n))*)", "gmi").exec(content);
-					    if (subset) {
-						    content = subset[1];
+						if( subset ){
+							content = subset[1];
 						}
 					}
 

--- a/src/ajaxInclude.js
+++ b/src/ajaxInclude.js
@@ -103,9 +103,9 @@
 						targetEl = target ? $( target ) : el;
 
 					if( o.proxy ){
-						var subset = content.match( new RegExp( "<entry url=[\"']?" + el.data( "url" ) + "[\"']?>(?:(?!</entry>)(.|\n))*", "gmi" ) );
-						if( subset ){
-							content = subset[ 0 ];
+						var subset = new RegExp("<entry url=[\"']?" + el.data("url") + "[\"']?>((?:(?!</entry>)(.|\n))*)", "gmi").exec(content);
+					    if (subset) {
+						    content = subset[1];
 						}
 					}
 


### PR DESCRIPTION
RegExp no longer captures the opening entry tag when grabbing wrapped
content from a proxy.