### PR TITLE
Fix entire proxy response included in page.

### DIFF
--- a/src/ajaxInclude.js
+++ b/src/ajaxInclude.js
@@ -104,9 +104,7 @@
 
 					if( o.proxy ){
 						var subset = new RegExp("<entry url=[\"']?" + el.data("url") + "[\"']?>((?:(?!</entry>)(.|\n))*)", "gmi").exec(content);
-						if( subset ){
-							content = subset[1];
-						}
+						content = (subset) ? subset[1] : '';
 					}
 
 					var filteredContent = el.triggerHandler( "ajaxIncludeFilter", [ content ] );


### PR DESCRIPTION
If a proxy response doesn't contain the data URL the entire response is
included into the page. Set content to be an empty string to prevent
this happening.
